### PR TITLE
changed socketio async mode from None to  'threading'

### DIFF
--- a/doorlockd.py
+++ b/doorlockd.py
@@ -57,7 +57,7 @@ html_title = 'Binary Kitchen Doorlock (%s - v%s)' % (__status__, __version__)
 
 webapp = Flask(__name__)
 webapp.config.from_pyfile('config.cfg')
-socketio = SocketIO(webapp, async_mode=None)
+socketio = SocketIO(webapp, async_mode='threading')
 Bootstrap(webapp)
 serial_port = webapp.config.get('SERIAL_PORT')
 simulate = webapp.config.get('SIMULATE')


### PR DESCRIPTION
Fixes a bug where a button press on the doorlock system does not emit the current system status to the web frontend because of a wrong async mode in the socketio library. 