### PR TITLE
Change minimum length of username string from 4 to 3

### DIFF
--- a/doorlockd.py
+++ b/doorlockd.py
@@ -333,7 +333,7 @@ class Logic:
 
 
 class AuthenticationForm(FlaskForm):
-    username = StringField('Username', [Length(min=4, max=25)])
+    username = StringField('Username', [Length(min=3, max=25)])
     password = PasswordField('Password', [DataRequired()])
     open = SubmitField('Open')
     close = SubmitField('Close')


### PR DESCRIPTION
This pull request drops the minimum character count of usernames from 4 to 3 to allow some users with short usernames (e.g. tom) to use the front end

Signed-off-by: Thomas Schmid <thomas.schmid@oth-regensburg.de>