### PR TITLE
Send lock/unlock messages using retain flag

### DIFF
--- a/scripts/post_lock
+++ b/scripts/post_lock
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mosquitto_pub -t kitchen/frontdoor/status -m "locked"
+mosquitto_pub -r -t kitchen/frontdoor/status -m "locked"

--- a/scripts/post_unlock
+++ b/scripts/post_unlock
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mosquitto_pub -t kitchen/frontdoor/status -m "unlocked"
+mosquitto_pub -r -t kitchen/frontdoor/status -m "unlocked"
 
 # Wakeup cashdesk
 wol -i 172.23.2.44 00:0b:ca:94:13:f1


### PR DESCRIPTION
When using the retain flag, the current status is saved on the broker. Applications which connect to the broker at any time can get the current doorstate. (Maybe interesting for the irc bot)